### PR TITLE
Migrate to generated bindings, using Clang.jl

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,6 @@
 /Manifest*.toml
 /docs/Manifest*.toml
 /docs/build/
+
+gen/Manifest.toml
+gen/Lib*.jl

--- a/Project.toml
+++ b/Project.toml
@@ -6,11 +6,13 @@ version = "0.3.0"
 [deps]
 Compat = "34da2185-b29b-5c13-b0c7-acf172513d20"
 Libdl = "8f399da3-3557-5675-b5ff-fb832c97cbdb"
+CEnum = "fa961155-64e5-5f13-b03f-caf6b980ea82"
 Qiskit_jll = "b54e8e98-f244-53b3-a8e8-4727a4907f76"
 
 [compat]
 Aqua = "0.8.14"
 Compat = "3.47, 4"
+CEnum = "0.5"
 Libdl = "1"
 Qiskit_jll = "~2.2.3"
 Test = "1"

--- a/gen/Project.toml
+++ b/gen/Project.toml
@@ -1,0 +1,3 @@
+[deps]
+Clang = "40e3b903-d033-50b4-a0cc-940c62c95e31"
+Qiskit_jll = "b54e8e98-f244-53b3-a8e8-4727a4907f76"

--- a/gen/generator.jl
+++ b/gen/generator.jl
@@ -1,0 +1,33 @@
+using Clang.Generators
+
+using Qiskit_jll
+
+cd(@__DIR__)
+
+include_dir = normpath(Qiskit_jll.artifact_dir, "include")
+qiskit_dir = joinpath(include_dir, "qiskit")
+
+# wrapper generator options
+options = load_options(joinpath(@__DIR__, "generator.toml"))
+
+# add compiler flags, e.g. "-DXXXXXXXXX"
+args = get_default_args()
+push!(args, "-I$include_dir")
+# XXX: this is a hack but necessary in order to avoid an error about the QkGate
+# enum being defined as two different things.
+push!(args, "-D__cplusplus")
+
+headers = [joinpath(include_dir, "qiskit.h")]
+for header in readdir(qiskit_dir)
+    if endswith(header, ".h")
+        push!(headers, joinpath(qiskit_dir, header))
+    end
+end
+# there is also an experimental `detect_headers` function for auto-detecting top-level headers in the directory
+# headers = detect_headers(qiskit_dir, args)
+
+# create context
+ctx = create_context(headers, args, options)
+
+# run generator
+build!(ctx)

--- a/gen/generator.toml
+++ b/gen/generator.toml
@@ -1,0 +1,7 @@
+[general]
+library_name = "libqiskit"
+output_file_path = "./LibQiskit.jl"
+module_name = "LibQiskit"
+jll_pkg_name = "Qiskit_jll"
+export_symbol_prefixes = ["Qk", "qk_", "QISKIT_"]
+output_ignorelist = ["QISKIT_VERSION_HEX"]

--- a/lib/LibQiskit.jl
+++ b/lib/LibQiskit.jl
@@ -1,0 +1,200 @@
+module LibQiskit
+
+using Qiskit_jll
+export Qiskit_jll
+
+using CEnum: CEnum, @cenum
+
+mutable struct QkQuantumRegister end
+
+mutable struct QkClassicalRegister end
+
+@cenum QkBitTerm::UInt8 begin
+    QkBitTerm_X = 0x0000000000000002
+    QkBitTerm_Plus = 0x000000000000000a
+    QkBitTerm_Minus = 0x0000000000000006
+    QkBitTerm_Y = 0x0000000000000003
+    QkBitTerm_Right = 0x000000000000000b
+    QkBitTerm_Left = 0x0000000000000007
+    QkBitTerm_Z = 0x0000000000000001
+    QkBitTerm_Zero = 0x0000000000000009
+    QkBitTerm_One = 0x0000000000000005
+end
+
+@cenum QkExitCode::UInt32 begin
+    QkExitCode_Success = 0x0000000000000000
+    QkExitCode_CInputError = 0x0000000000000064
+    QkExitCode_NullPointerError = 0x0000000000000065
+    QkExitCode_AlignmentError = 0x0000000000000066
+    QkExitCode_IndexError = 0x0000000000000067
+    QkExitCode_DuplicateIndexError = 0x0000000000000068
+    QkExitCode_ArithmeticError = 0x00000000000000c8
+    QkExitCode_MismatchedQubits = 0x00000000000000c9
+    QkExitCode_ExpectedUnitary = 0x00000000000000ca
+    QkExitCode_TargetError = 0x000000000000012c
+    QkExitCode_TargetInstAlreadyExists = 0x000000000000012d
+    QkExitCode_TargetQargMismatch = 0x000000000000012e
+    QkExitCode_TargetInvalidQargsKey = 0x000000000000012f
+    QkExitCode_TargetInvalidInstKey = 0x0000000000000130
+    QkExitCode_TranspilerError = 0x0000000000000190
+end
+
+@cenum QkDelayUnit::UInt8 begin
+    QkDelayUnit_S = 0x0000000000000000
+    QkDelayUnit_MS = 0x0000000000000001
+    QkDelayUnit_US = 0x0000000000000002
+    QkDelayUnit_NS = 0x0000000000000003
+    QkDelayUnit_PS = 0x0000000000000004
+end
+
+@cenum QkGate::UInt8 begin
+    QkGate_GlobalPhase = 0x0000000000000000
+    QkGate_H = 0x0000000000000001
+    QkGate_I = 0x0000000000000002
+    QkGate_X = 0x0000000000000003
+    QkGate_Y = 0x0000000000000004
+    QkGate_Z = 0x0000000000000005
+    QkGate_Phase = 0x0000000000000006
+    QkGate_R = 0x0000000000000007
+    QkGate_RX = 0x0000000000000008
+    QkGate_RY = 0x0000000000000009
+    QkGate_RZ = 0x000000000000000a
+    QkGate_S = 0x000000000000000b
+    QkGate_Sdg = 0x000000000000000c
+    QkGate_SX = 0x000000000000000d
+    QkGate_SXdg = 0x000000000000000e
+    QkGate_T = 0x000000000000000f
+    QkGate_Tdg = 0x0000000000000010
+    QkGate_U = 0x0000000000000011
+    QkGate_U1 = 0x0000000000000012
+    QkGate_U2 = 0x0000000000000013
+    QkGate_U3 = 0x0000000000000014
+    QkGate_CH = 0x0000000000000015
+    QkGate_CX = 0x0000000000000016
+    QkGate_CY = 0x0000000000000017
+    QkGate_CZ = 0x0000000000000018
+    QkGate_DCX = 0x0000000000000019
+    QkGate_ECR = 0x000000000000001a
+    QkGate_Swap = 0x000000000000001b
+    QkGate_ISwap = 0x000000000000001c
+    QkGate_CPhase = 0x000000000000001d
+    QkGate_CRX = 0x000000000000001e
+    QkGate_CRY = 0x000000000000001f
+    QkGate_CRZ = 0x0000000000000020
+    QkGate_CS = 0x0000000000000021
+    QkGate_CSdg = 0x0000000000000022
+    QkGate_CSX = 0x0000000000000023
+    QkGate_CU = 0x0000000000000024
+    QkGate_CU1 = 0x0000000000000025
+    QkGate_CU3 = 0x0000000000000026
+    QkGate_RXX = 0x0000000000000027
+    QkGate_RYY = 0x0000000000000028
+    QkGate_RZZ = 0x0000000000000029
+    QkGate_RZX = 0x000000000000002a
+    QkGate_XXMinusYY = 0x000000000000002b
+    QkGate_XXPlusYY = 0x000000000000002c
+    QkGate_CCX = 0x000000000000002d
+    QkGate_CCZ = 0x000000000000002e
+    QkGate_CSwap = 0x000000000000002f
+    QkGate_RCCX = 0x0000000000000030
+    QkGate_C3X = 0x0000000000000031
+    QkGate_C3SX = 0x0000000000000032
+    QkGate_RC3X = 0x0000000000000033
+end
+
+mutable struct QkCircuit end
+
+mutable struct QkObs end
+
+mutable struct QkTarget end
+
+mutable struct QkTargetEntry end
+
+mutable struct QkTranspileLayout end
+
+mutable struct QkVF2LayoutResult end
+
+struct QkOpCount
+    name::Ptr{Cchar}
+    count::Csize_t
+end
+
+struct QkOpCounts
+    data::Ptr{QkOpCount}
+    len::Csize_t
+end
+
+struct QkCircuitInstruction
+    name::Ptr{Cchar}
+    qubits::Ptr{UInt32}
+    clbits::Ptr{UInt32}
+    params::Ptr{Cdouble}
+    num_qubits::UInt32
+    num_clbits::UInt32
+    num_params::UInt32
+end
+
+struct QkComplex64
+    re::Cdouble
+    im::Cdouble
+end
+
+struct QkObsTerm
+    coeff::QkComplex64
+    len::Csize_t
+    bit_terms::Ptr{QkBitTerm}
+    indices::Ptr{UInt32}
+    num_qubits::UInt32
+end
+
+struct QkSabreLayoutOptions
+    max_iterations::Csize_t
+    num_swap_trials::Csize_t
+    num_random_trials::Csize_t
+    seed::UInt64
+end
+
+struct QkTranspileOptions
+    optimization_level::UInt8
+    seed::Int64
+    approximation_degree::Cdouble
+end
+
+struct QkTranspileResult
+    circuit::Ptr{QkCircuit}
+    layout::Ptr{QkTranspileLayout}
+end
+
+function qk_complex64_from_native(arg1)
+    ccall((:qk_complex64_from_native, libqiskit), QkComplex64, (Cint,), arg1)
+end
+
+const QISKIT_RELEASE_LEVEL_DEV = 0x0a
+
+const QISKIT_RELEASE_LEVEL_BETA = 0x0b
+
+const QISKIT_RELEASE_LEVEL_RC = 0x0c
+
+const QISKIT_RELEASE_LEVEL_FINAL = 0x0f
+
+const QISKIT_VERSION_MAJOR = 2
+
+const QISKIT_VERSION_MINOR = 2
+
+const QISKIT_VERSION_PATCH = 3
+
+const QISKIT_RELEASE_LEVEL = QISKIT_RELEASE_LEVEL_FINAL
+
+const QISKIT_RELEASE_SERIAL = 0
+
+const QISKIT_VERSION = "2.2.3"
+
+# exports
+const PREFIXES = ["Qk", "qk_", "QISKIT_"]
+for name in names(@__MODULE__; all=true), prefix in PREFIXES
+    if startswith(string(name), prefix)
+        @eval export $name
+    end
+end
+
+end # module

--- a/src/Qiskit.jl
+++ b/src/Qiskit.jl
@@ -16,6 +16,9 @@ using Compat
 
 module C
 
+libdir = joinpath(@__DIR__, "..", "lib")
+include(joinpath(libdir, "LibQiskit.jl"))
+
 using Qiskit_jll
 
 libqiskit = Qiskit_jll.libqiskit

--- a/src/c_circuit.jl
+++ b/src/c_circuit.jl
@@ -10,63 +10,7 @@
 # copyright notice, and modified files need to carry a notice indicating
 # that they have been altered from the originals.
 
-@enum QkGate::UInt8 begin
-    QkGate_GlobalPhase = 0
-    QkGate_H = 1
-    QkGate_I = 2
-    QkGate_X = 3
-    QkGate_Y = 4
-    QkGate_Z = 5
-    QkGate_Phase = 6
-    QkGate_R = 7
-    QkGate_RX = 8
-    QkGate_RY = 9
-    QkGate_RZ = 10
-    QkGate_S = 11
-    QkGate_Sdg = 12
-    QkGate_SX = 13
-    QkGate_SXdg = 14
-    QkGate_T = 15
-    QkGate_Tdg = 16
-    QkGate_U = 17
-    QkGate_U1 = 18
-    QkGate_U2 = 19
-    QkGate_U3 = 20
-    QkGate_CH = 21
-    QkGate_CX = 22
-    QkGate_CY = 23
-    QkGate_CZ = 24
-    QkGate_DCX = 25
-    QkGate_ECR = 26
-    QkGate_Swap = 27
-    QkGate_ISwap = 28
-    QkGate_CPhase = 29
-    QkGate_CRX = 30
-    QkGate_CRY = 31
-    QkGate_CRZ = 32
-    QkGate_CS = 33
-    QkGate_CSdg = 34
-    QkGate_CSX = 35
-    QkGate_CU = 36
-    QkGate_CU1 = 37
-    QkGate_CU3 = 38
-    QkGate_RXX = 39
-    QkGate_RYY = 40
-    QkGate_RZZ = 41
-    QkGate_RZX = 42
-    QkGate_XXMinusYY = 43
-    QkGate_XXPlusYY = 44
-    QkGate_CCX = 45
-    QkGate_CCZ = 46
-    QkGate_CSwap = 47
-    QkGate_RCCX = 48
-    QkGate_C3X = 49
-    QkGate_C3SX = 50
-    QkGate_RC3X = 51
-end
-
-mutable struct QkCircuit
-end
+import .LibQiskit: QkGate, QkCircuit, QkDelayUnit, QkOpCount, QkOpCounts
 
 mutable struct QkCircuitInstruction
     name::Cstring
@@ -220,14 +164,6 @@ function qk_circuit_unitary(qc::Ref{QkCircuit}, matrix::AbstractMatrix{<:Number}
     check_exit_code(@ccall libqiskit.qk_circuit_unitary(qc::Ref{QkCircuit}, row_major_matrix::Ref{Complex{Cdouble}}, qubits0::Ref{UInt32}, length(qubits)::UInt32, check_input::Cuchar)::QkExitCode)
 end
 
-@enum QkDelayUnit::UInt8 begin
-    QkDelayUnit_S = 0
-    QkDelayUnit_MS = 1
-    QkDelayUnit_US = 2
-    QkDelayUnit_NS = 3
-    QkDelayUnit_PS = 4
-end
-
 function qk_circuit_delay(qc::Ref{QkCircuit}, qubit::Integer, duration::Real, unit::QkDelayUnit; offset::Int = 1)::Nothing
     check_not_null(qc)
     if !(duration >= 0)
@@ -239,16 +175,6 @@ function qk_circuit_delay(qc::Ref{QkCircuit}, qubit::Integer, duration::Real, un
     qubit0 = qubit - offset
     check_exit_code(@ccall libqiskit.qk_circuit_delay(qc::Ref{QkCircuit}, qubit0::UInt32, duration::Float64, unit::UInt8)::QkExitCode)
     nothing
-end
-
-mutable struct QkOpCount
-    name::Ptr{Cchar}
-    count::Csize_t
-end
-
-struct QkOpCounts
-    data::Ptr{QkOpCount}
-    len::Csize_t
 end
 
 function qk_circuit_count_ops(qc::Ref{QkCircuit})
@@ -269,6 +195,7 @@ export qk_circuit_gate, qk_circuit_measure, qk_circuit_reset, qk_circuit_barrier
 # Export enum instances
 for e in (QkGate, QkDelayUnit)
     for s in instances(e)
+        @eval import .LibQiskit: $(Symbol(s))
         @eval export $(Symbol(s))
     end
 end

--- a/src/c_exit_code.jl
+++ b/src/c_exit_code.jl
@@ -10,23 +10,7 @@
 # copyright notice, and modified files need to carry a notice indicating
 # that they have been altered from the originals.
 
-@enum QkExitCode::UInt32 begin
-    QkExitCode_Success = 0
-    QkExitCode_CInputError = 100
-    QkExitCode_NullPointerError = 101
-    QkExitCode_AlignmentError = 102
-    QkExitCode_IndexError = 103
-    QkExitCode_DuplicateIndexError = 104
-    QkExitCode_ArithmeticError = 200
-    QkExitCode_MismatchedQubits = 201
-    QkExitCode_ExpectedUnitary = 202
-    QkExitCode_TargetError = 300
-    QkExitCode_TargetInstAlreadyExists = 301
-    QkExitCode_TargetQargMismatch = 302
-    QkExitCode_TargetInvalidQargsKey = 303
-    QkExitCode_TargetInvalidInstKey = 304
-    QkExitCode_TranspilerError = 400
-end
+import .LibQiskit: QkExitCode
 
 function check_exit_code(code::QkExitCode, error_string::Ptr{Cchar} = Ptr{Cchar}(C_NULL))::Nothing
     if error_string != C_NULL
@@ -64,5 +48,15 @@ function check_exit_code(code::QkExitCode, error_string::Ptr{Cchar} = Ptr{Cchar}
         throw(ErrorException("Transpilation failed."))
     else
         throw(ErrorException("Unrecognized error code from Qiskit: $code"))
+    end
+end
+
+export QkExitCode
+
+# Export enum instances
+for e in (QkExitCode,)
+    for s in instances(e)
+        @eval import .LibQiskit: $(Symbol(s))
+        @eval export $(Symbol(s))
     end
 end

--- a/src/c_observable.jl
+++ b/src/c_observable.jl
@@ -10,23 +10,10 @@
 # copyright notice, and modified files need to carry a notice indicating
 # that they have been altered from the originals.
 
-@enum QkBitTerm::UInt8 begin
-    QkBitTerm_X = 0b0010
-    QkBitTerm_Y = 0b0011
-    QkBitTerm_Z = 0b0001
-    QkBitTerm_Plus = 0b1010
-    QkBitTerm_Minus = 0b0110
-    QkBitTerm_Right = 0b1011
-    QkBitTerm_Left = 0b0111
-    QkBitTerm_Zero = 0b1001
-    QkBitTerm_One = 0b0101
-end
+import .LibQiskit: QkBitTerm, QkObs
 
 function qk_bitterm_label(bit_term::QkBitTerm)::Char
     @ccall libqiskit.qk_bitterm_label(bit_term::UInt8)::UInt8
-end
-
-mutable struct QkObs
 end
 
 function qk_obs_free(obs::Ptr{QkObs})
@@ -55,6 +42,7 @@ export QkBitTerm, qk_bitterm_label, QkObs, qk_obs_free, qk_obs_zero, qk_obs_num_
 # Export enum instances
 for e in (QkBitTerm,)
     for s in instances(e)
+        @eval import .LibQiskit: $(Symbol(s))
         @eval export $(Symbol(s))
     end
 end

--- a/src/c_target.jl
+++ b/src/c_target.jl
@@ -10,8 +10,7 @@
 # copyright notice, and modified files need to carry a notice indicating
 # that they have been altered from the originals.
 
-mutable struct QkTargetEntry
-end
+import .LibQiskit: QkTargetEntry, QkTarget
 
 function check_not_null(obj::Ptr{QkTargetEntry})::Nothing
     if obj == C_NULL
@@ -32,9 +31,6 @@ end
 function qk_target_entry_add_property(target_entry::Ref{QkTargetEntry}, qubits::AbstractVector{<:Integer}, duration::Real, error::Real)::Nothing
     qubits0 = Vector{UInt32}(qubits .- 1)
     check_exit_code(@ccall(libqiskit.qk_target_entry_add_property(target_entry::Ref{QkTargetEntry}, qubits0::Ref{UInt32}, length(qubits0)::UInt32, duration::Cdouble, error::Cdouble)::QkExitCode))
-end
-
-mutable struct QkTarget
 end
 
 function check_not_null(obj::Ptr{QkTarget})::Nothing

--- a/src/c_transpile.jl
+++ b/src/c_transpile.jl
@@ -10,24 +10,16 @@
 # copyright notice, and modified files need to carry a notice indicating
 # that they have been altered from the originals.
 
-mutable struct QkTranspileOptions
-end
+import .LibQiskit: QkTranspileOptions, QkTranspileLayout, QkTranspileResult
 
-mutable struct QkTranspileLayout
-end
-
-mutable struct QkTranspileResult
-    circuit::Ptr{QkCircuit}
-    layout::Ptr{QkTranspileLayout}
-    QkTranspileResult() = new(C_NULL, C_NULL)
-end
+QkTranspileResult() = QkTranspileResult(C_NULL, C_NULL)
 
 function qk_transpile(qc::Ref{QkCircuit}, target::Ref{QkTarget})::Ref{QkTranspileResult}
-    result = QkTranspileResult()
+    result = Ref(QkTranspileResult())
     error_string = Ptr{Cchar}(C_NULL)
     exit_code = @ccall libqiskit.qk_transpile(qc::Ref{QkCircuit}, target::Ref{QkTarget}, C_NULL::Ptr{QkTranspileOptions}, result::Ref{QkTranspileResult}, error_string::Ref{Ptr{Cchar}})::QkExitCode
     check_exit_code(exit_code, error_string)
-    return Ref(result)
+    return result
 end
 
 export qk_transpile


### PR DESCRIPTION
This removes the duplication of the enums and structs, at the very least.