### PR TITLE
Fix `count_ops` memory cleanup and expose `QuantumCircuit.count_ops`

### DIFF
--- a/src/c_circuit.jl
+++ b/src/c_circuit.jl
@@ -178,12 +178,17 @@ function qk_circuit_delay(qc::Ref{QkCircuit}, qubit::Integer, duration::Real, un
 end
 
 function qk_circuit_count_ops(qc::Ref{QkCircuit})
-    opcounts = @ccall libqiskit.qk_circuit_count_ops(qc::Ref{QkCircuit})::QkOpCounts
+    check_not_null(qc)
+    opcounts = Ref(@ccall libqiskit.qk_circuit_count_ops(qc::Ref{QkCircuit})::QkOpCounts)
     retval = Tuple{String, Int}[]
-    sizehint!(retval, opcounts.len)
-    for i in 1:opcounts.len
-        op_count = unsafe_load(opcounts.data, i)
-        push!(retval, (unsafe_string(op_count.name), op_count.count))
+    try
+        sizehint!(retval, opcounts[].len)
+        for i in 1:opcounts[].len
+            op_count = unsafe_load(opcounts[].data, i)
+            push!(retval, (unsafe_string(op_count.name), op_count.count))
+        end
+    finally
+        @ccall libqiskit.qk_opcounts_clear(opcounts::Ref{QkOpCounts})::Cvoid
     end
     return retval
 end

--- a/src/circuit.jl
+++ b/src/circuit.jl
@@ -163,7 +163,7 @@ function Base.iterate(qcdata::QuantumCircuitData, state)
 end
 
 function Base.propertynames(obj::QuantumCircuit; private::Bool = false)
-    union(fieldnames(typeof(obj)), (:data, :num_qubits, :num_clbits, :num_instructions, :reset, :measure, :barrier, :unitary, :h, :id, :x, :y, :z, :p, :r, :rx, :ry, :rz, :s, :sdg, :sx, :sxdg, :t, :tdg, :u, :ch, :cx, :cy, :cz, :dcx, :ecr, :swap, :iswap, :cp, :crx, :cry, :crz, :cs, :csdg, :csx, :cu, :rxx, :ryy, :rzz, :rzx, :ccx, :ccz, :cswap, :rccx, :unitary, :rcccx))
+    union(fieldnames(typeof(obj)), (:data, :num_qubits, :num_clbits, :num_instructions, :count_ops, :reset, :measure, :barrier, :unitary, :h, :id, :x, :y, :z, :p, :r, :rx, :ry, :rz, :s, :sdg, :sx, :sxdg, :t, :tdg, :u, :ch, :cx, :cy, :cz, :dcx, :ecr, :swap, :iswap, :cp, :crx, :cry, :crz, :cs, :csdg, :csx, :cu, :rxx, :ryy, :rzz, :rzx, :ccx, :ccz, :cswap, :rccx, :unitary, :rcccx))
 end
 
 function Base.getproperty(qc::QuantumCircuit, sym::Symbol)
@@ -175,6 +175,8 @@ function Base.getproperty(qc::QuantumCircuit, sym::Symbol)
         return qk_circuit_num_clbits(qc)
     elseif sym === :num_instructions
         return qk_circuit_num_instructions(qc)
+    elseif sym === :count_ops
+        return qk_circuit_count_ops(qc)
     elseif sym === :reset
         return ResetInstructionClosure(qc)
     elseif sym === :measure

--- a/src/circuit.jl
+++ b/src/circuit.jl
@@ -28,6 +28,7 @@ Available read-only properties:
 
 The additional properties are methods:
 
+- `count_ops()` - returns a Dict of operation counts
 - `reset(qubit)`
 - `measure(qubit, clbit)`
 - `barrier(qubit1, qubit2, ...)`
@@ -130,6 +131,22 @@ function (cl::UnitaryInstructionClosure)(matrix::AbstractMatrix{<:Number}, qubit
     qk_circuit_unitary(cl.qc, matrix, qubits)
 end
 
+struct CountOpsClosure
+    qc::QuantumCircuit
+end
+
+"""
+    count_ops() -> Dict
+
+Return operation counts for the circuit.
+
+Each call to this function performs O(n) work to traverse the circuit.
+If you need to access counts for multiple operations, store the result in a variable.
+"""
+function (cl::CountOpsClosure)()::Dict{String, Int}
+    Dict(qk_circuit_count_ops(cl.qc))
+end
+
 struct QuantumCircuitData <: AbstractVector{CircuitInstruction}
     circuit::QuantumCircuit
 end
@@ -176,7 +193,7 @@ function Base.getproperty(qc::QuantumCircuit, sym::Symbol)
     elseif sym === :num_instructions
         return qk_circuit_num_instructions(qc)
     elseif sym === :count_ops
-        return qk_circuit_count_ops(qc)
+        return CountOpsClosure(qc)
     elseif sym === :reset
         return ResetInstructionClosure(qc)
     elseif sym === :measure
@@ -304,8 +321,6 @@ qk_circuit_unitary(qc::QuantumCircuit, matrix, qubits; check_input::Bool = true)
     qk_circuit_unitary(qc.ptr, matrix, qubits; check_input, offset=qc.offset)
 
 qk_circuit_delay(qc::QuantumCircuit, args...) = qk_circuit_delay(qc.ptr, args...; offset=qc.offset)
-
-qk_circuit_count_ops(qc::QuantumCircuit) = qk_circuit_count_ops(qc.ptr)
 
 export QuantumCircuit, CircuitInstruction
 @compat public QuantumCircuitData

--- a/src/circuit.jl
+++ b/src/circuit.jl
@@ -322,5 +322,7 @@ qk_circuit_unitary(qc::QuantumCircuit, matrix, qubits; check_input::Bool = true)
 
 qk_circuit_delay(qc::QuantumCircuit, args...) = qk_circuit_delay(qc.ptr, args...; offset=qc.offset)
 
+qk_circuit_count_ops(qc::QuantumCircuit) = qk_circuit_count_ops(qc.ptr)
+
 export QuantumCircuit, CircuitInstruction
 @compat public QuantumCircuitData

--- a/src/circuit.jl
+++ b/src/circuit.jl
@@ -28,7 +28,7 @@ Available read-only properties:
 
 The additional properties are methods:
 
-- `count_ops()` - returns a Dict of operation counts
+- `count_ops()` - returns a `Dict` of operation counts
 - `reset(qubit)`
 - `measure(qubit, clbit)`
 - `barrier(qubit1, qubit2, ...)`

--- a/src/circuit.jl
+++ b/src/circuit.jl
@@ -136,7 +136,7 @@ struct CountOpsClosure
 end
 
 """
-    count_ops() -> Dict
+    count_ops() -> Dict{String, Int}
 
 Return operation counts for the circuit.
 

--- a/test/test_circuit.jl
+++ b/test/test_circuit.jl
@@ -36,8 +36,8 @@
         "measure" => 1,
         "reset" => 1,
     )
-    @test Dict(qk_circuit_count_ops(qc)) == expected_op_counts
-    @test Dict(qc.count_ops) == expected_op_counts
+    @test qk_circuit_count_ops(qc) == expected_op_counts
+    @test qc.count_ops() == expected_op_counts
     @test qk_circuit_get_instruction(qc, 1).params == [0.25]
     @test qk_circuit_get_instruction(qc, 3).params == [0.3, 0]
     @test qk_circuit_get_instruction(qc, 3).qubits == [2, 3]

--- a/test/test_circuit.jl
+++ b/test/test_circuit.jl
@@ -26,6 +26,18 @@
     @test qc.num_instructions == 8
     instructions = [instruction.name for instruction in qc.data]
     @test instructions == ["rz", "h", "xx_plus_yy", "delay", "unitary", "barrier", "measure", "reset"]
+    expected_op_counts = Dict(
+        "rz" => 1,
+        "h" => 1,
+        "xx_plus_yy" => 1,
+        "delay" => 1,
+        "unitary" => 1,
+        "barrier" => 1,
+        "measure" => 1,
+        "reset" => 1,
+    )
+    @test Dict(qk_circuit_count_ops(qc)) == expected_op_counts
+    @test Dict(qc.count_ops) == expected_op_counts
     @test qk_circuit_get_instruction(qc, 1).params == [0.25]
     @test qk_circuit_get_instruction(qc, 3).params == [0.3, 0]
     @test qk_circuit_get_instruction(qc, 3).qubits == [2, 3]

--- a/test/test_circuit.jl
+++ b/test/test_circuit.jl
@@ -36,7 +36,7 @@
         "measure" => 1,
         "reset" => 1,
     )
-    @test qk_circuit_count_ops(qc) == expected_op_counts
+    @test Dict(qk_circuit_count_ops(qc)) == expected_op_counts
     @test qc.count_ops() == expected_op_counts
     @test qk_circuit_get_instruction(qc, 1).params == [0.25]
     @test qk_circuit_get_instruction(qc, 3).params == [0.3, 0]


### PR DESCRIPTION
### Summary
This change fixes the `qk_circuit_count_ops` wrapper so it always releases the allocated `QkOpCounts` buffer returned by the C API, preventing a memory leak. It also exposes `count_ops` as a `QuantumCircuit` property for parity with the existing circuit API.

### Changes

- Updated `c_circuit.jl` to wrap `qk_circuit_count_ops` in a try/finally block and call `qk_opcounts_clear` after converting the result.
- Added `count_ops` to `QuantumCircuit` property dispatch in `circuit.jl`.
- Added tests in `test_circuit.jl` covering both `qk_circuit_count_ops(qc)` and `qc.count_ops`.