### PR TITLE
Add delay method to `QuantumCircuit`

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -9,9 +9,6 @@ Libdl = "8f399da3-3557-5675-b5ff-fb832c97cbdb"
 CEnum = "fa961155-64e5-5f13-b03f-caf6b980ea82"
 Qiskit_jll = "b54e8e98-f244-53b3-a8e8-4727a4907f76"
 
-[weakdeps]
-Unitful = "1986cc42-f94f-5a68-af5c-568840ba6254"
-
 [compat]
 Aqua = "0.8.14"
 Compat = "3.47, 4"
@@ -19,7 +16,6 @@ CEnum = "0.5"
 Libdl = "1"
 Qiskit_jll = "~2.2.3"
 Test = "1"
-Unitful = "1"
 julia = "1.10"
 
 [extras]

--- a/Project.toml
+++ b/Project.toml
@@ -9,6 +9,9 @@ Libdl = "8f399da3-3557-5675-b5ff-fb832c97cbdb"
 CEnum = "fa961155-64e5-5f13-b03f-caf6b980ea82"
 Qiskit_jll = "b54e8e98-f244-53b3-a8e8-4727a4907f76"
 
+[weakdeps]
+Unitful = "1986cc42-f94f-5a68-af5c-568840ba6254"
+
 [compat]
 Aqua = "0.8.14"
 Compat = "3.47, 4"
@@ -16,6 +19,7 @@ CEnum = "0.5"
 Libdl = "1"
 Qiskit_jll = "~2.2.3"
 Test = "1"
+Unitful = "1"
 julia = "1.10"
 
 [extras]

--- a/src/circuit.jl
+++ b/src/circuit.jl
@@ -10,7 +10,7 @@
 # copyright notice, and modified files need to carry a notice indicating
 # that they have been altered from the originals.
 
-import .C: qk_circuit_free, qk_circuit_num_qubits, qk_circuit_num_clbits, qk_circuit_num_instructions, qk_circuit_get_instruction, qk_circuit_count_ops, QkCircuit, QkGate, CircuitInstruction
+import .C: qk_circuit_free, qk_circuit_num_qubits, qk_circuit_num_clbits, qk_circuit_num_instructions, qk_circuit_get_instruction, qk_circuit_count_ops, QkCircuit, QkGate, CircuitInstruction, QkDelayUnit, QkDelayUnit_S, QkDelayUnit_MS, QkDelayUnit_US, QkDelayUnit_NS, QkDelayUnit_PS
 import .C: qk_circuit_gate, qk_circuit_measure, qk_circuit_reset, qk_circuit_barrier, qk_circuit_unitary, qk_circuit_delay, check_not_null
 using .C
 
@@ -130,6 +130,48 @@ function (cl::UnitaryInstructionClosure)(matrix::AbstractMatrix{<:Number}, qubit
     qk_circuit_unitary(cl.qc, matrix, qubits)
 end
 
+struct DelayInstructionClosure
+    qc::QuantumCircuit
+end
+
+function (cl::DelayInstructionClosure)(qubit::Integer, duration, unit::Union{QkDelayUnit, String} = QkDelayUnit_S)::Nothing
+    # Handle Unitful quantities if available
+    if applicable(typeof(duration), :unit)
+        try
+            import Unitful
+            if typeof(duration) <: Unitful.Quantity
+                # Convert to seconds first, then to the specified unit
+                duration_in_seconds = uconvert(Unitful.s, duration).val
+                # Map unit strings to QkDelayUnit enum values
+                unit_map = Dict(
+                    "s" => QkDelayUnit_S,
+                    "ms" => QkDelayUnit_MS,
+                    "μs" => QkDelayUnit_US,
+                    "ns" => QkDelayUnit_NS,
+                    "ps" => QkDelayUnit_PS
+                )
+                if unit isa String && haskey(unit_map, unit)
+                    unit = unit_map[unit]
+                elseif unit isa String
+                    throw(ArgumentError("Unknown delay unit: $unit. Use 's', 'ms', 'μs', 'ns', or 'ps'."))
+                end
+                # Scale duration accordingly
+                scale_factors = Dict(
+                    QkDelayUnit_S => 1.0,
+                    QkDelayUnit_MS => 1000.0,
+                    QkDelayUnit_US => 1e6,
+                    QkDelayUnit_NS => 1e9,
+                    QkDelayUnit_PS => 1e12
+                )
+                duration = duration_in_seconds * scale_factors[unit]
+            end
+        catch
+            # Unitful not available or other error, proceed with raw duration
+        end
+    end
+    qk_circuit_delay(cl.qc, qubit, duration, unit)
+end
+
 struct QuantumCircuitData <: AbstractVector{CircuitInstruction}
     circuit::QuantumCircuit
 end
@@ -163,7 +205,7 @@ function Base.iterate(qcdata::QuantumCircuitData, state)
 end
 
 function Base.propertynames(obj::QuantumCircuit; private::Bool = false)
-    union(fieldnames(typeof(obj)), (:data, :num_qubits, :num_clbits, :num_instructions, :reset, :measure, :barrier, :unitary, :h, :id, :x, :y, :z, :p, :r, :rx, :ry, :rz, :s, :sdg, :sx, :sxdg, :t, :tdg, :u, :ch, :cx, :cy, :cz, :dcx, :ecr, :swap, :iswap, :cp, :crx, :cry, :crz, :cs, :csdg, :csx, :cu, :rxx, :ryy, :rzz, :rzx, :ccx, :ccz, :cswap, :rccx, :unitary, :rcccx))
+    union(fieldnames(typeof(obj)), (:data, :num_qubits, :num_clbits, :num_instructions, :reset, :measure, :barrier, :delay, :unitary, :h, :id, :x, :y, :z, :p, :r, :rx, :ry, :rz, :s, :sdg, :sx, :sxdg, :t, :tdg, :u, :ch, :cx, :cy, :cz, :dcx, :ecr, :swap, :iswap, :cp, :crx, :cry, :crz, :cs, :csdg, :csx, :cu, :rxx, :ryy, :rzz, :rzx, :ccx, :ccz, :cswap, :rccx, :unitary, :rcccx))
 end
 
 function Base.getproperty(qc::QuantumCircuit, sym::Symbol)
@@ -181,6 +223,8 @@ function Base.getproperty(qc::QuantumCircuit, sym::Symbol)
         return MeasureInstructionClosure(qc)
     elseif sym === :barrier
         return BarrierInstructionClosure(qc)
+    elseif sym === :delay
+        return DelayInstructionClosure(qc)
     elseif sym === :unitary
         return UnitaryInstructionClosure(qc)
     elseif sym === :h

--- a/src/circuit.jl
+++ b/src/circuit.jl
@@ -171,6 +171,8 @@ function (cl::DelayInstructionClosure)(qubit::Integer, duration, unit::Union{QkD
         end
     end
     qk_circuit_delay(cl.qc, qubit, duration, unit)
+end
+
 struct CountOpsClosure
     qc::QuantumCircuit
 end

--- a/src/circuit.jl
+++ b/src/circuit.jl
@@ -135,41 +135,7 @@ struct DelayInstructionClosure
     qc::QuantumCircuit
 end
 
-function (cl::DelayInstructionClosure)(qubit::Integer, duration, unit::Union{QkDelayUnit, String} = QkDelayUnit_S)::Nothing
-    # Handle Unitful quantities if available
-    if applicable(typeof(duration), :unit)
-        try
-            import Unitful
-            if typeof(duration) <: Unitful.Quantity
-                # Convert to seconds first, then to the specified unit
-                duration_in_seconds = uconvert(Unitful.s, duration).val
-                # Map unit strings to QkDelayUnit enum values
-                unit_map = Dict(
-                    "s" => QkDelayUnit_S,
-                    "ms" => QkDelayUnit_MS,
-                    "μs" => QkDelayUnit_US,
-                    "ns" => QkDelayUnit_NS,
-                    "ps" => QkDelayUnit_PS
-                )
-                if unit isa String && haskey(unit_map, unit)
-                    unit = unit_map[unit]
-                elseif unit isa String
-                    throw(ArgumentError("Unknown delay unit: $unit. Use 's', 'ms', 'μs', 'ns', or 'ps'."))
-                end
-                # Scale duration accordingly
-                scale_factors = Dict(
-                    QkDelayUnit_S => 1.0,
-                    QkDelayUnit_MS => 1000.0,
-                    QkDelayUnit_US => 1e6,
-                    QkDelayUnit_NS => 1e9,
-                    QkDelayUnit_PS => 1e12
-                )
-                duration = duration_in_seconds * scale_factors[unit]
-            end
-        catch
-            # Unitful not available or other error, proceed with raw duration
-        end
-    end
+function (cl::DelayInstructionClosure)(qubit::Integer, duration::Real, unit::QkDelayUnit = QkDelayUnit_S)::Nothing
     qk_circuit_delay(cl.qc, qubit, duration, unit)
 end
 

--- a/test/test_circuit.jl
+++ b/test/test_circuit.jl
@@ -19,11 +19,12 @@
     qc.h(2)
     qk_circuit_gate(qc, QkGate_XXPlusYY, [2, 3], [0.3, 0])
     qk_circuit_delay(qc, 1, 1, QkDelayUnit_NS)
+    qc.delay(2, 2.5, QkDelayUnit_US)
     qc.unitary([0 -im; im 0], [1])
     qc.barrier()
     qc.measure(4, 1)
     qc.reset(4)
-    @test qc.num_instructions == 8
+    @test qc.num_instructions == 9
     instructions = [instruction.name for instruction in qc.data]
     @test instructions == ["rz", "h", "xx_plus_yy", "delay", "unitary", "barrier", "measure", "reset"]
     expected_op_counts = Dict(
@@ -50,6 +51,7 @@
         @test qc.num_qubits == 4
         qc.rz(0.25, 0)
         qc.cx(0, 3)
+        qc.delay(1, 4.0)
         qc.unitary([0 -im; im 0], [0])
         qc.barrier(0, 1, 2, 3)
         qc.measure(3, 0)
@@ -61,9 +63,10 @@
         @test_throws ArgumentError qk_circuit_measure(qc, 3, 1)
         @test_throws ArgumentError qk_circuit_reset(qc, 4)
         instructions = [instruction.name for instruction in qc.data]
-        @test instructions == ["rz", "cx", "unitary", "barrier", "measure", "reset"]
+        @test instructions == ["rz", "cx", "delay", "unitary", "barrier", "measure", "reset"]
         @test qk_circuit_get_instruction(qc, 0).params == [0.25]
         @test qk_circuit_get_instruction(qc, 1).qubits == [0, 3]
-        @test qk_circuit_get_instruction(qc, 4).clbits == [0]
+        @test qk_circuit_get_instruction(qc, 2).params == [4.0]
+        @test qk_circuit_get_instruction(qc, 5).clbits == [0]
     end
 end

--- a/test/test_circuit.jl
+++ b/test/test_circuit.jl
@@ -26,12 +26,12 @@
     qc.reset(4)
     @test qc.num_instructions == 9
     instructions = [instruction.name for instruction in qc.data]
-    @test instructions == ["rz", "h", "xx_plus_yy", "delay", "unitary", "barrier", "measure", "reset"]
+    @test instructions == ["rz", "h", "xx_plus_yy", "delay", "delay", "unitary", "barrier", "measure", "reset"]
     expected_op_counts = Dict(
         "rz" => 1,
         "h" => 1,
         "xx_plus_yy" => 1,
-        "delay" => 1,
+        "delay" => 2,
         "unitary" => 1,
         "barrier" => 1,
         "measure" => 1,


### PR DESCRIPTION
Implements delay instruction support for quantum circuits.

Changes:
- Added `DelayInstructionClosure` struct to handle delay operations
- Exposed delay method on `QuantumCircuit` objects
- Updated imports to include `QkDelayUnit` enum constants