### PR TITLE
Add note about cbindgen C23 enum PR

### DIFF
--- a/gen/generator.jl
+++ b/gen/generator.jl
@@ -14,7 +14,8 @@ options = load_options(joinpath(@__DIR__, "generator.toml"))
 args = get_default_args()
 push!(args, "-I$include_dir")
 # XXX: this is a hack but necessary in order to avoid an error about the QkGate
-# enum being defined as two different things.
+# enum being defined as two different things.  See upstream PR at
+# https://github.com/mozilla/cbindgen/pull/1156
 push!(args, "-D__cplusplus")
 
 headers = [joinpath(include_dir, "qiskit.h")]


### PR DESCRIPTION
This comment references the PR at https://github.com/mozilla/cbindgen/pull/1156 alongside the necessary workaround until that is merged and released.