### PR TITLE
Implement `circuit.unitary` and add tests

### DIFF
--- a/src/circuit.jl
+++ b/src/circuit.jl
@@ -132,8 +132,8 @@ function (cl::UnitaryInstructionClosure)(matrix::AbstractMatrix{<:Number}, qubit
     qk_circuit_unitary(cl.qc, matrix, qubits; check_input)
 end
 
-function (cl::UnitaryInstructionClosure)(matrix::AbstractMatrix{<:Number}, qubit::Integer; check_input::Bool = true)::Nothing
-    qk_circuit_unitary(cl.qc, matrix, [qubit]; check_input)
+function (cl::UnitaryInstructionClosure)(matrix::AbstractMatrix{<:Number}, qubits::Int...; check_input::Bool = true)::Nothing
+    qk_circuit_unitary(cl.qc, matrix, collect(qubits); check_input)
 end
 
 struct DelayInstructionClosure

--- a/src/circuit.jl
+++ b/src/circuit.jl
@@ -128,8 +128,12 @@ struct UnitaryInstructionClosure
     qc::QuantumCircuit
 end
 
-function (cl::UnitaryInstructionClosure)(matrix::AbstractMatrix{<:Number}, qubits::AbstractVector{<:Integer})::Nothing
-    qk_circuit_unitary(cl.qc, matrix, qubits)
+function (cl::UnitaryInstructionClosure)(matrix::AbstractMatrix{<:Number}, qubits::AbstractVector{<:Integer}; check_input::Bool = true)::Nothing
+    qk_circuit_unitary(cl.qc, matrix, qubits; check_input)
+end
+
+function (cl::UnitaryInstructionClosure)(matrix::AbstractMatrix{<:Number}, qubit::Integer; check_input::Bool = true)::Nothing
+    qk_circuit_unitary(cl.qc, matrix, [qubit]; check_input)
 end
 
 struct DelayInstructionClosure
@@ -307,8 +311,6 @@ function Base.getproperty(qc::QuantumCircuit, sym::Symbol)
     elseif sym === :
         return GateClosure{QkGate_C3SX}(qc, , )
         =#
-    elseif sym === :unitary
-        throw(NotImplementedError())
     elseif sym === :rcccx
         return GateClosure{QkGate_RC3X}(qc, 4, 0)
     else

--- a/test/test_circuit.jl
+++ b/test/test_circuit.jl
@@ -89,4 +89,38 @@
         @test qc.data[5].params == [100.0]
         @test_throws ArgumentError qc.delay(1, 1 * Unitful.Ms)
     end
+
+    @testset "Unitary interface" begin
+        qc = QuantumCircuit(3, 0)
+
+        # single-qubit via vector
+        qc.unitary([0 1; 1 0], [1])
+        @test qc.num_instructions == 1
+        @test qc.data[1].name == "unitary"
+        @test qc.data[1].qubits == [1]
+
+        # single-qubit via scalar
+        qc.unitary([0 -im; im 0], 2)
+        @test qc.num_instructions == 2
+        @test qc.data[2].name == "unitary"
+        @test qc.data[2].qubits == [2]
+
+        # two-qubit unitary (CNOT as dense matrix)
+        cnot = [1 0 0 0; 0 0 0 1; 0 0 1 0; 0 1 0 0]
+        qc.unitary(cnot, [1, 2])
+        @test qc.num_instructions == 3
+        @test qc.data[3].name == "unitary"
+        @test qc.data[3].qubits == [1, 2]
+
+        # check_input keyword forwarded
+        qc.unitary([0 1; 1 0], [3]; check_input = false)
+        @test qc.num_instructions == 4
+
+        # wrong matrix size throws
+        @test_throws ArgumentError qk_circuit_unitary(qc, [1 0; 0 1], [1, 2])
+
+        # out-of-range qubit throws
+        @test_throws ArgumentError qc.unitary([0 1; 1 0], [4])
+        @test_throws ArgumentError qc.unitary([0 1; 1 0], 4)
+    end
 end

--- a/test/test_circuit.jl
+++ b/test/test_circuit.jl
@@ -113,7 +113,12 @@
         @test qc.data[3].qubits == [1, 2]
 
         # check_input keyword forwarded
-        qc.unitary([0 1; 1 0], [3]; check_input = false)
+        non_unitary = [1.0 1.0; 0.0 1.0]
+        qc.unitary(non_unitary, [3]; check_input = false)
+        @test qc.num_instructions == 4
+
+        # check_input=true enforces unitarity; expects clean error, not panic
+        @test_throws ErrorException qc.unitary(non_unitary, [3]; check_input = true)
         @test qc.num_instructions == 4
 
         # wrong matrix size throws


### PR DESCRIPTION
Implemented `circuit.unitary` and remove dead `NotImplementedError` . Adds scalar-qubit overload `circuit.unitary(matrix, qubit)`) and `check_input` keyword to mirror the [python api](https://quantum.cloud.ibm.com/docs/en/api/qiskit/qiskit.circuit.QuantumCircuit) . New `@testset "Unitary interface"` covers single/multi-qubit, scalar qubit, `check_input`, bad matrix size, and out-of-range qubits. Note: `label=` not supported, no slot in the C binding.




closes: #51