### PR TITLE
Add pinned JuliaFormatter tooling and CI format check

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -13,6 +13,17 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: ${{ startsWith(github.ref, 'refs/pull/') }}
 jobs:
+  format:
+    name: Format check
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+      - uses: julia-actions/setup-julia@v3
+        with:
+          version: '1'
+      - uses: julia-actions/cache@v3
+      - name: Check formatting
+        run: make format-check
   test:
     name: Julia ${{ matrix.version }} - ${{ matrix.os }} - ${{ matrix.arch }}
     runs-on: ${{ matrix.os }}

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,86 @@
+# AGENTS.md
+
+Guidance for AI agents and contributors working in this repository.
+
+## What this package is
+
+Qiskit.jl is a Julia wrapper around the [Qiskit C API](https://docs.quantum.ibm.com/api/qiskit-c).
+The underlying C library is provided by the `Qiskit_jll` binary artifact. This package
+exposes both a low-level C binding layer and a higher-level, Pythonic Julia interface.
+
+A crucial convention: everything is **1-indexed**, not 0-indexed as in Python Qiskit,
+because 1-based indexing is the Julia norm.
+
+## Repository layout
+
+- `lib/LibQiskit.jl` — **AUTO-GENERATED. Do not edit by hand.** This file is produced by
+  the code in `gen/` (via Clang.jl) from the Qiskit C headers shipped in `Qiskit_jll`.
+  Any manual change here will be lost the next time the bindings are regenerated.
+- `gen/` — the binding generator. `gen/generator.jl` runs Clang.jl over the C headers
+  to regenerate `lib/LibQiskit.jl`; `gen/generator.toml` holds the generator config
+  (export prefixes `Qk`/`qk_`/`QISKIT_`, ignorelist, etc.); `gen/Project.toml` pins the
+  generator's own deps (Clang, Qiskit_jll).
+- `src/` — the hand-written Julia package.
+  - `Qiskit.jl` — top-level module. Defines an inner `module C` that `include`s the
+    generated `lib/LibQiskit.jl` plus the `c_*.jl` thin wrappers, then includes the
+    high-level files.
+  - `c_*.jl` (`c_circuit.jl`, `c_target.jl`, `c_transpile.jl`, `c_observable.jl`,
+    `c_exit_code.jl`) — thin wrappers over the generated C bindings.
+  - `circuit.jl`, `target.jl`, `transpile.jl`, `observable.jl` — the high-level,
+    Pythonic Julia API (e.g. `QuantumCircuit`, `Target`, `transpile`).
+- `test/` — test suite, entry point `test/runtests.jl`. Also a good source of usage examples.
+- `ext/` — package extensions (e.g. `QiskitUnitfulExt` for `Unitful`).
+- `docs/` — documentation source.
+- `format/` — a self-contained environment that pins the exact `JuliaFormatter` version
+  used to format this repo (see **Formatting** below). Like `gen/`, it has its own
+  `Project.toml`/`Manifest.toml` and is invoked with `julia --project=format`.
+
+## Regenerating the C bindings
+
+When the `Qiskit_jll` version changes (or the C API changes), regenerate `lib/LibQiskit.jl`:
+
+```sh
+julia --project=gen -e 'import Pkg; Pkg.instantiate()'
+julia --project=gen gen/generator.jl
+```
+
+Then review the diff and run the formatter and tests. Never edit `lib/LibQiskit.jl` directly.
+
+## Running tests
+
+```sh
+julia --project=. -e 'import Pkg; Pkg.test()'
+```
+
+The test target also pulls in `Aqua` (quality checks) and `Unitful` (extension testing);
+see `Project.toml` `[targets]`.
+
+## Formatting
+
+This repo uses [JuliaFormatter.jl](https://domluna.github.io/JuliaFormatter.jl/) per
+`.JuliaFormatter.toml`. The exact formatter version is pinned in its own environment
+under `format/` (so the result does not depend on whatever JuliaFormatter happens to be
+in your global environment). Format before committing:
+
+```sh
+make format
+```
+
+which runs:
+
+```sh
+julia --project=format -e 'import Pkg; Pkg.instantiate(); using JuliaFormatter; format(".")'
+```
+
+Use `make format-check` in CI to fail (non-zero exit) when files are unformatted.
+
+To bump the pinned version, edit the `[compat]` bound in `format/Project.toml`, then run
+`julia --project=format -e 'import Pkg; Pkg.update()'` and commit the updated
+`format/Manifest.toml`.
+
+## Conventions
+
+- **1-based indexing** everywhere in the public API (qubits, clbits, etc.).
+- The high-level API mirrors Python Qiskit's `QuantumCircuit` method names where practical.
+- Keep new code consistent with the existing style in the surrounding file.
+- Supported platforms: Linux and macOS (x86_64 and aarch64).

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,23 @@
+JULIA ?= julia
+
+.PHONY: help format format-check test gen
+
+help:
+	@echo "Targets:"
+	@echo "  format        Format the repo with the pinned JuliaFormatter (format/ env)"
+	@echo "  format-check  Check formatting without modifying files (exits non-zero if unformatted)"
+	@echo "  test          Run the test suite"
+	@echo "  gen           Regenerate lib/LibQiskit.jl from the Qiskit C headers (gen/ env)"
+
+format:
+	$(JULIA) --project=format -e 'import Pkg; Pkg.instantiate(); using JuliaFormatter; format(".")'
+
+format-check:
+	$(JULIA) --project=format -e 'import Pkg; Pkg.instantiate(); using JuliaFormatter; format(".") || (@error "Some files are not formatted; run \`make format\`"; exit(1))'
+
+test:
+	$(JULIA) --project=. -e 'import Pkg; Pkg.test()'
+
+gen:
+	$(JULIA) --project=gen -e 'import Pkg; Pkg.instantiate()'
+	$(JULIA) --project=gen gen/generator.jl

--- a/format/Manifest.toml
+++ b/format/Manifest.toml
@@ -1,0 +1,111 @@
+# This file is machine-generated - editing it directly is not advised
+
+julia_version = "1.12.6"
+manifest_format = "2.0"
+project_hash = "77875d3c243003c2bd88609ddb5f2f903ad6a7be"
+
+[[deps.Base64]]
+uuid = "2a0f44e3-6c83-55bd-87e4-b1978d98bd5f"
+version = "1.11.0"
+
+[[deps.CommonMark]]
+deps = ["PrecompileTools"]
+git-tree-sha1 = "731edf630eb23140a3c7a2e74d4186f562996d76"
+uuid = "a80b9123-70ca-4bc0-993e-6e3bcb318db6"
+version = "1.0.2"
+
+    [deps.CommonMark.extensions]
+    CommonMarkMarkdownASTExt = "MarkdownAST"
+    CommonMarkMarkdownExt = "Markdown"
+
+    [deps.CommonMark.weakdeps]
+    Markdown = "d6f4376e-aef5-505a-96c1-9c027394607a"
+    MarkdownAST = "d0879d2d-cac2-40c8-9cee-1863dc0c7391"
+
+[[deps.Dates]]
+deps = ["Printf"]
+uuid = "ade2ca70-3891-5945-98fb-dc099432e06a"
+version = "1.11.0"
+
+[[deps.Glob]]
+git-tree-sha1 = "246c628cec062230b7d183aab88841fa94fcabe9"
+uuid = "c27321d9-0574-5035-807b-f59d2c89b15c"
+version = "1.5.0"
+
+[[deps.InteractiveUtils]]
+deps = ["Markdown"]
+uuid = "b77e0a4c-d291-57a0-90e8-8db25a27a240"
+version = "1.11.0"
+
+[[deps.JuliaFormatter]]
+deps = ["CommonMark", "Glob", "JuliaSyntax", "PrecompileTools", "TOML", "Test"]
+git-tree-sha1 = "a7f790373ef74e64f176afbe75ece2baf6dfc74d"
+uuid = "98e50ef6-434e-11e9-1051-2b60c6c9e899"
+version = "2.8.5"
+
+[[deps.JuliaSyntax]]
+git-tree-sha1 = "0d4b3dab95018bcf3925204475693d9f09dc45b8"
+uuid = "70703baa-626e-46a2-a12c-08ffd08c73b4"
+version = "1.0.2"
+
+[[deps.JuliaSyntaxHighlighting]]
+deps = ["StyledStrings"]
+uuid = "ac6e5ff7-fb65-4e79-a425-ec3bc9c03011"
+version = "1.12.0"
+
+[[deps.Logging]]
+uuid = "56ddb016-857b-54e1-b83d-db4d58db5568"
+version = "1.11.0"
+
+[[deps.Markdown]]
+deps = ["Base64", "JuliaSyntaxHighlighting", "StyledStrings"]
+uuid = "d6f4376e-aef5-505a-96c1-9c027394607a"
+version = "1.11.0"
+
+[[deps.PrecompileTools]]
+deps = ["Preferences"]
+git-tree-sha1 = "edbeefc7a4889f528644251bdb5fc9ab5348bc2c"
+uuid = "aea7be01-6a6a-4083-8856-8a6e6704d82a"
+version = "1.3.4"
+
+[[deps.Preferences]]
+deps = ["TOML"]
+git-tree-sha1 = "8b770b60760d4451834fe79dd483e318eee709c4"
+uuid = "21216c6a-2e73-6563-6e65-726566657250"
+version = "1.5.2"
+
+[[deps.Printf]]
+deps = ["Unicode"]
+uuid = "de0858da-6303-5e67-8744-51eddeeeb8d7"
+version = "1.11.0"
+
+[[deps.Random]]
+deps = ["SHA"]
+uuid = "9a3f8284-a2c9-5f02-9a11-845980a1fd5c"
+version = "1.11.0"
+
+[[deps.SHA]]
+uuid = "ea8e919c-243c-51af-8825-aaa63cd721ce"
+version = "0.7.0"
+
+[[deps.Serialization]]
+uuid = "9e88b42a-f829-5b0c-bbe9-9e923198166b"
+version = "1.11.0"
+
+[[deps.StyledStrings]]
+uuid = "f489334b-da3d-4c2e-b8f0-e476e12c162b"
+version = "1.11.0"
+
+[[deps.TOML]]
+deps = ["Dates"]
+uuid = "fa267f1f-6049-4f14-aa54-33bafae1ed76"
+version = "1.0.3"
+
+[[deps.Test]]
+deps = ["InteractiveUtils", "Logging", "Random", "Serialization"]
+uuid = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
+version = "1.11.0"
+
+[[deps.Unicode]]
+uuid = "4ec0a83e-493e-50e2-b9ac-8f72acf5a8f5"
+version = "1.11.0"

--- a/format/Project.toml
+++ b/format/Project.toml
@@ -1,0 +1,5 @@
+[deps]
+JuliaFormatter = "98e50ef6-434e-11e9-1051-2b60c6c9e899"
+
+[compat]
+JuliaFormatter = "=2.8.5"


### PR DESCRIPTION
## What

Adds a pinned formatting setup so contributors and CI all format with the **exact same JuliaFormatter version**, regardless of what's installed globally.

## Changes

- **`format/`** — a self-contained environment that pins `JuliaFormatter` to `2.8.5` (`Project.toml` `[compat] = "=2.8.5"` + a committed `Manifest.toml`). Mirrors the existing `gen/` pattern.
- **`Makefile`** — short task runner:
  - `make format` — format the repo with the pinned formatter
  - `make format-check` — fail (non-zero exit) if anything is unformatted; used by CI
  - `make test`, `make gen` — convenience wrappers for the existing commands
- **`.github/workflows/CI.yml`** — new **Format check** job (Linux-only, since formatting is platform/version independent) running `make format-check` on PRs and the merge queue.
- **`AGENTS.md`** — documents the `format/` env and the `make` targets.

## Why

The old instruction `julia -e 'using JuliaFormatter; format(".")'` relied on whatever JuliaFormatter happened to be in the user's global environment, giving inconsistent results across contributors and CI. Pinning in a dedicated env removes that drift without polluting anyone's global environment.

## Notes / follow-up

- To make this a *hard* merge gate, **"Format check"** still needs to be added to the required status checks in branch protection / merge-queue settings for `main`.
- To bump the version later: edit `format/Project.toml` `[compat]`, run `julia --project=format -e 'import Pkg; Pkg.update()'`, and commit the updated `format/Manifest.toml`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)