### PR TITLE
Force GC after tests so finalizer free-paths are covered

### DIFF
--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -24,4 +24,13 @@ using Unitful
     include("test_target.jl")
     include("test_transpiler.jl")
     include("test_observable.jl")
+
+    # The wrapper types (`QuantumCircuit`, `Target`, `TargetEntry`,
+    # `SparseObservable`, transpile layouts) register finalizers that call the
+    # corresponding `qk_*_free` C functions. Those finalizer bodies only run
+    # when the garbage collector reclaims the objects, which is nondeterministic
+    # and may not happen before the test process exits — leaving the free paths
+    # showing as uncovered (and inconsistently so across CI matrix jobs). Force
+    # a collection here so the finalizers run deterministically.
+    GC.gc()
 end


### PR DESCRIPTION
## Background

The wrapper types (`QuantumCircuit`, `Target`, `TargetEntry`, `SparseObservable`, transpile layouts) register finalizers that call the corresponding `qk_*_free` C functions. Those finalizer bodies run only when the garbage collector reclaims the objects — which is nondeterministic and may not happen before the test process exits. So the free paths frequently show as **uncovered**, and inconsistently so from run to run and across CI matrix jobs.

This was made visible in #64: switching coverage upload from every Linux matrix job to a single job dropped reported coverage by ~6%. The cause turned out not to be version- or platform-gated code (there is none in `src/`), but **GC nondeterminism in finalizers**. With every Linux job uploading, a finalizer line that GC happened to trigger on *any* of the runs counted as covered (the union across jobs masked the flakiness). A single job removed that masking.

## Change

Force a garbage collection at the end of the test suite so the finalizers run deterministically:

```julia
    GC.gc()
end
```

A single `GC.gc()` was verified locally (via `Pkg.test(coverage=true)`) to cover the reachable `qk_*_free` finalizer bodies — e.g. `qk_circuit_free` and `qk_target_free` go from uncovered to hit. (I confirmed one pass suffices; a second `GC.gc()` produced identical coverage, so it is not included.)

Note: `TargetEntry`'s free ccall remains uncovered, because entries added to a target have their ownership transferred to the C side (`ptr` is `C_NULL` by finalization time), so that line is genuinely unreachable in normal use — not something forced GC should or does paper over.

## Relationship to #64

This addresses the root cause of the coverage drop observed in #64. #64 is left open for now pending a separate decision on the upload strategy.

🤖 Generated with [Claude Code](https://claude.com/claude-code)